### PR TITLE
one update in OpenGL.arrays.vbo ?

### DIFF
--- a/python/part2/part2.py
+++ b/python/part2/part2.py
@@ -34,9 +34,9 @@ class Part2(object):
 
         #Setup vertex buffer objects and share them with OpenCL as GLBuffers
         self.pos_vbo.bind()
-        self.pos_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.pos_vbo.buffers[0]))
+        self.pos_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.pos_vbo.buffer))
         self.col_vbo.bind()
-        self.col_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.col_vbo.buffers[0]))
+        self.col_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.col_vbo.buffer))
 
         #pure OpenCL arrays
         self.vel_cl = cl.Buffer(self.ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=vel)


### PR DESCRIPTION
on my MacBook Pro 5.1  this line throws this error with buffers[0] :    

self.arr_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.arrvbo.buffers[0]))
  File "vbo.pyx", line 175, in OpenGL_accelerate.vbo.VBO.**getattr** (src/vbo.c:1784)
AttributeError: 'numpy.ndarray' object has no attribute 'buffers'

with int(self.arrvbo.buffer) it works perfectly
