### PR TITLE
Python Part2: Fixed an exception raised when trying to share GL buffers to CL

### DIFF
--- a/python/part2/part2.py
+++ b/python/part2/part2.py
@@ -34,9 +34,15 @@ class Part2(object):
 
         #Setup vertex buffer objects and share them with OpenCL as GLBuffers
         self.pos_vbo.bind()
-        self.pos_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.pos_vbo.buffer))
+        #For some there is no single buffer but an array of buffers
+        #https://github.com/enjalot/adventures_in_opencl/commit/61bfd373478767249fe8a3aa77e7e36b22d453c4
+        try:
+            self.pos_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.pos_vbo.buffer))
+            self.col_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.col_vbo.buffer))
+        except AttributeError:
+            self.pos_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.pos_vbo.buffers[0]))
+            self.col_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.col_vbo.buffers[0]))
         self.col_vbo.bind()
-        self.col_cl = cl.GLBuffer(self.ctx, mf.READ_WRITE, int(self.col_vbo.buffer))
 
         #pure OpenCL arrays
         self.vel_cl = cl.Buffer(self.ctx, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=vel)


### PR DESCRIPTION
Problem discussed in a little more detail here:
[61bfd373478767249fe8a3aa77e7e36b22d453c4](https://github.com/enjalot/adventures_in_opencl/commit/61bfd373478767249fe8a3aa77e7e36b22d453c4)
